### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/mobi/boilr/boilr/utils/AlarmAlertWakeLock.java
+++ b/src/main/java/mobi/boilr/boilr/utils/AlarmAlertWakeLock.java
@@ -11,6 +11,9 @@ public class AlarmAlertWakeLock {
 
 	private static PowerManager.WakeLock sCpuWakeLock = null;
 
+	private AlarmAlertWakeLock() {
+	}
+
 	public static PowerManager.WakeLock createPartialWakeLock(Context context) {
 		PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
 		return pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "AlarmAlertWakeLock");

--- a/src/main/java/mobi/boilr/boilr/utils/Conversions.java
+++ b/src/main/java/mobi/boilr/boilr/utils/Conversions.java
@@ -21,6 +21,9 @@ public class Conversions {
 	private static final long MILIS_IN_HOUR = 3600000; // 60 * 60 * 1000
 	private static final long MILIS_IN_DAY = 86400000; // 24 * 60 * 60 * 1000
 
+	private Conversions() {
+	}
+
 	public static String formatMilis(long milis, Context context) {
 		String formated;
 		if(milis < MILIS_IN_MINUTE) {

--- a/src/main/java/mobi/boilr/boilr/utils/IconToast.java
+++ b/src/main/java/mobi/boilr/boilr/utils/IconToast.java
@@ -13,7 +13,10 @@ public class IconToast {
 	
 	private static final int[] warningAttrs = new int[] { R.attr.ic_action_warning /*index 0*/};
 	private static final int[] infoAttrs = new int[] { R.attr.ic_action_about /*index 0*/};
-	
+
+	private IconToast() {
+	}
+
 	public static void warning(Context context, CharSequence text) {
 		show(context, text, warningAttrs);
 	}

--- a/src/main/java/mobi/boilr/boilr/utils/Languager.java
+++ b/src/main/java/mobi/boilr/boilr/utils/Languager.java
@@ -10,6 +10,9 @@ import android.content.res.Configuration;
 import android.preference.PreferenceManager;
 
 public class Languager {
+	private Languager() {
+	}
+
 	public static void setLanguage(Context context){
 		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
 		String language = sharedPreferences.getString(SettingsFragment.PREF_KEY_LANGUAGE, "");

--- a/src/main/java/mobi/boilr/boilr/utils/NotificationKlaxon.java
+++ b/src/main/java/mobi/boilr/boilr/utils/NotificationKlaxon.java
@@ -27,6 +27,10 @@ public class NotificationKlaxon {
 	private static MediaPlayer sMediaPlayer = null;
 	private static boolean sStarted = false;
 	private static final Map<Integer, Integer> sAlertToStreamType;
+
+	private NotificationKlaxon() {
+	}
+
 	static {
 		Map<Integer, Integer> aux = new HashMap<Integer, Integer>();
 		aux.put(RingtoneManager.TYPE_RINGTONE, AudioManager.STREAM_RING);

--- a/src/main/java/mobi/boilr/boilr/utils/Notifications.java
+++ b/src/main/java/mobi/boilr/boilr/utils/Notifications.java
@@ -42,6 +42,9 @@ public final class Notifications {
 	public static final String ACTION_CLEAR_NET_NOTIF = "ACTION_CLEAR_NET_NOTIF";
 	private static SharedPreferences sSharedPrefs = null;
 
+	private Notifications() {
+	}
+
 	private static void statusBarNotifAux(Context context, Alarm alarm, String firingReasonTitle, String firingReasonBody) {
 		if(sSmallUpArrowBitmap == null) {
 			int tickerGreen = context.getResources().getColor(R.color.tickergreen);

--- a/src/main/java/mobi/boilr/boilr/utils/Themer.java
+++ b/src/main/java/mobi/boilr/boilr/utils/Themer.java
@@ -17,6 +17,9 @@ public class Themer {
 
 	private static Theme curTheme = null;
 
+	private Themer() {
+	}
+
 	public static void changeTheme(String newTheme) {
 		curTheme = Theme.valueOf(newTheme);
 	}

--- a/src/main/java/mobi/boilr/boilr/utils/VersionTracker.java
+++ b/src/main/java/mobi/boilr/boilr/utils/VersionTracker.java
@@ -42,7 +42,10 @@ public class VersionTracker {
 	private static int currentVersionCode;
 	public static boolean isFirstRun;
 	private static Context context;
-    
+
+	private VersionTracker() {
+	}
+
 	public static void showChangeLog(Activity activity) {
 		context = activity;
 		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(activity.getApplicationContext());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.